### PR TITLE
Don't assume user is SLIME user

### DIFF
--- a/picolisp-mode.el
+++ b/picolisp-mode.el
@@ -477,8 +477,8 @@ This function thus overrides those overrides, and:
 
 * ensures that the value of `eldoc-documentation-function' is
   `picolisp--eldoc-function'."
-  (slime-mode 0)
-  (slime-autodoc-mode 0)
+  (and (fboundp 'slime-mode) (slime-mode 0))
+  (and (fboundp 'slime-autodoc-mode) (slime-autodoc-mode 0))
   (make-local-variable 'eldoc-documentation-function)
   (setq eldoc-documentation-function #'picolisp--eldoc-function))
 


### PR DESCRIPTION
If the user doesn't use SLIME, `M-x picolisp-mode` will trigger the following error.
```
picolisp--disable-slime-modes: Symbol’s function definition is void: slime-mode
```
This fix corrects that.