### PR TITLE
Fix: conditionally disable slime mode only if installed

### DIFF
--- a/picolisp-mode.el
+++ b/picolisp-mode.el
@@ -477,8 +477,9 @@ This function thus overrides those overrides, and:
 
 * ensures that the value of `eldoc-documentation-function' is
   `picolisp--eldoc-function'."
-  (slime-mode 0)
-  (slime-autodoc-mode 0)
+  (when (require 'slime nil :noerror)
+    (slime-mode 0)
+    (slime-autodoc-mode 0))
   (make-local-variable 'eldoc-documentation-function)
   (setq eldoc-documentation-function #'picolisp--eldoc-function))
 


### PR DESCRIPTION
I'm not sure if this is the best way to accomplish this but it works on my system, I'm running antergos and Spacemacs